### PR TITLE
Audio: Dynamic tempo from backings

### DIFF
--- a/src/main/java/app/StateManager.java
+++ b/src/main/java/app/StateManager.java
@@ -3,7 +3,6 @@ package app;
 import app.communication.*;
 import app.mapping.*;
 import app.ui.App;
-import audio.Constants;
 import audio.Sonifier;
 import audio.synth.EvInstrData;
 import audio.synth.InstrumentEnum;
@@ -209,12 +208,7 @@ public class StateManager {
 			InstrumentDataRaw[] passedInstrRawDatas = new InstrumentDataRaw[instrRawDatas.size()];
 			passedInstrRawDatas = instrRawDatas.toArray(passedInstrRawDatas);
 
-			double numberBeatsRaw = (Constants.TEMPO / 60f) * mapping.getSoundLength();
-			// get number of beats to nearest multiple of 16 so that audio always lasts for
-			// a full multiple of 4 bars
-			int numberBeats = (int) Math.round(numberBeatsRaw / 16) * 16;
-
-			PlaybackController pbc = Sonifier.sonify(passedInstrRawDatas, evInstrDatas, numberBeats);
+			PlaybackController pbc = Sonifier.sonify(passedInstrRawDatas, evInstrDatas, mapping.getSoundLength());
 
 			double[][] pricesForMusicData = new double[pricesLen][sonifiableSet.length];
 			String[] sonifiableNames = new String[sonifiableSet.length];

--- a/src/main/java/audio/Constants.java
+++ b/src/main/java/audio/Constants.java
@@ -1,7 +1,7 @@
 package audio;
 
 public class Constants {
-    public static int TEMPO = 108;
+    public static int TEMPO;
     public static int SAMPLE_RATE = 44100;
     public static int CHANNEL_NO = 2;
 }

--- a/src/main/java/audio/mixer/Backing.java
+++ b/src/main/java/audio/mixer/Backing.java
@@ -10,19 +10,11 @@ import java.util.Random;
 
 public class Backing {
     private final int SAMPLE_BARS = 4;
-    private final int bars;
     private double[] groove;
     private double[][] fills;
     private final Random random = new Random();
 
-    public Backing(int beats) {
-        // int division is fine here because beats will always be multiple of 4
-        this.bars = beats / 4;
-    }
-
-    public double[] getBacking() throws AppError {
-        setSamplesRandomly();
-
+    public double[] getBacking( int bars ) {
         int seconds = (int) Math.ceil( (bars * 4) / (Constants.TEMPO / 60f) );
         double[] out = new double[seconds * Constants.SAMPLE_RATE * Constants.CHANNEL_NO];
 
@@ -39,15 +31,14 @@ public class Backing {
         return out;
     }
 
-    private void setSamplesRandomly() throws AppError {
+    public int setSamplesAndGetTempo() throws AppError {
         //TODO: I think this method of getting file names doesn't work in a JAR. Needs to be changed for release
         File directory = new File("./src/main/resources/audio/backings");
         List<String> backings = List.of(Objects.requireNonNull(directory.list()));
 
         backings = backings.stream().filter((string) -> string.contains("groove") || string.contains("fill")).toList();
-        backings = backings.stream().filter( (string) -> string.startsWith( Integer.toString(Constants.TEMPO) ) ).toList();
         if (backings.isEmpty()) {
-            throw new AppError("Encountered error while selecting backing track: No valid backings of matching tempo found");
+            throw new AppError("Encountered error while selecting backing track: No valid backings found");
         }
 
         String randomSample = backings.get( random.nextInt(backings.size()) );
@@ -65,11 +56,13 @@ public class Backing {
         for (int i = 0; i < fillNames.size(); i++) {
             fills[i] = SampleLoader.loadBackingSample(fillNames.get(i));
         }
+
+        return Integer.parseInt(metaData[0]);
     }
 
 
     /**
-     * this currently assumes that all backing samples are of length 4, might be expanded
+     * this currently assumes that all backing samples are of length 4
      */
     private double[] chooseSample(int bar) {
         if (bar % 8 == 4) {

--- a/src/main/java/audio/synth/Test.java
+++ b/src/main/java/audio/synth/Test.java
@@ -2,10 +2,8 @@ package audio.synth;
 
 // freq: 440,  493.88,  523.25,  587.33,  659.25,  698.46,  783.99,  880.00
 
-import app.AppError;
 import audio.Constants;
 import audio.Util;
-import audio.mixer.Backing;
 import audio.mixer.SampleLoader;
 import audio.synth.envelopes.ADSR;
 import audio.synth.fx.Effect;
@@ -75,10 +73,6 @@ public class Test {
 
             double[] synthLine = new SynthLine(instrData, 6).synthesize();
 
-            // backing track test
-            Backing backing = new Backing(32);
-            double[] b = backing.getBacking();
-
             // mod freq factor of 1.5 seems to resemble a clarinet - though rather rough,
             // could not yet figure out how to add more harmonics
             // TODO add calculation to actually play given freq when modulation and not just
@@ -105,8 +99,6 @@ public class Test {
             sdl.close();
             System.out.println("ended main method");
         } catch (LineUnavailableException e) {
-            throw new RuntimeException(e);
-        } catch (AppError e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
I found it unnecessarily limiting to get all backing tracks to the same length so I thought we could just get the tempo dynamically from the backing's file name. All I had to do for that is:

1. move calculation of beats from configured length from StateManager to Sonifier
2. at the very beginning of Sonifier.sonify(), call Backing.setSamples(), return the tempo and set it to Constants.TEMPO
3. swap out Backing.getBacking()-call to use the previously initialised instance of Backing.

I don't see any reasons why this would cause problems on a technical level. From a user-standpoint it means that they get better backing tracks and more varied sonifications in general. It also means that there's a greater element of randomness to the audio output but I don't think that's necessarily problematic.

Feedback is very welcome :)