### PR TITLE
Issue #83

### DIFF
--- a/src/main/java/app/StateManager.java
+++ b/src/main/java/app/StateManager.java
@@ -316,17 +316,14 @@ public class StateManager {
 			EvInstrData[] evInstrDatas = new EvInstrData[evInstrRawDatas.size()];
 			evInstrDatas = evInstrRawDatas.toArray(evInstrDatas);
 
-			Backing backing        = Sonifier.getBacking();
-			int lengthInBeats      = Sonifier.getLengthInBeats(mapping.getSoundLength());
-			double lengthInSeconds = Sonifier.getLengthInSeconds(mapping.getSoundLength(), lengthInBeats);
-			PlaybackController pbc = Sonifier.sonify(passedInstrRawDatas, evInstrDatas, backing, lengthInSeconds, lengthInBeats);
+			PlaybackController pbc = Sonifier.sonify(passedInstrRawDatas, evInstrDatas, mapping.getSoundLength());
 
 			String[] sonifiableNames = new String[sonifiables.length];
 			for (int i = 0; i < sonifiableNames.length; i++) {
 				sonifiableNames[i] = DataRepo.getSonifiableName(sonifiables[i]);
 			}
 			isCurrentlySonifying = false;
-			return new MusicData(pbc, sonifiableNames, priceMap.values(), lengthInSeconds);
+			return new MusicData(pbc, sonifiableNames, priceMap.values());
 		}, null);
 
 	}

--- a/src/main/java/app/StateManager.java
+++ b/src/main/java/app/StateManager.java
@@ -4,6 +4,7 @@ import app.communication.*;
 import app.mapping.*;
 import app.ui.App;
 import audio.Sonifier;
+import audio.mixer.Backing;
 import audio.synth.EvInstrData;
 import audio.synth.EvInstrEnum;
 import audio.synth.InstrumentEnum;
@@ -315,14 +316,17 @@ public class StateManager {
 			EvInstrData[] evInstrDatas = new EvInstrData[evInstrRawDatas.size()];
 			evInstrDatas = evInstrRawDatas.toArray(evInstrDatas);
 
-			PlaybackController pbc = Sonifier.sonify(passedInstrRawDatas, evInstrDatas, mapping.getSoundLength());
+			Backing backing        = Sonifier.getBacking();
+			int lengthInBeats      = Sonifier.getLengthInBeats(mapping.getSoundLength());
+			double lengthInSeconds = Sonifier.getLengthInSeconds(mapping.getSoundLength(), lengthInBeats);
+			PlaybackController pbc = Sonifier.sonify(passedInstrRawDatas, evInstrDatas, backing, lengthInSeconds, lengthInBeats);
 
 			String[] sonifiableNames = new String[sonifiables.length];
 			for (int i = 0; i < sonifiableNames.length; i++) {
 				sonifiableNames[i] = DataRepo.getSonifiableName(sonifiables[i]);
 			}
 			isCurrentlySonifying = false;
-			return new MusicData(pbc, sonifiableNames, priceMap.values());
+			return new MusicData(pbc, sonifiableNames, priceMap.values(), lengthInSeconds);
 		}, null);
 
 	}

--- a/src/main/java/app/communication/MusicData.java
+++ b/src/main/java/app/communication/MusicData.java
@@ -18,11 +18,13 @@ public class MusicData {
 	public List<XYChart.Series<Integer, Double>> prices;
 	public double maxPrice; // @Perfomance we already calculate this in the SM, so we could just get the value from there
 	public Calendar[] dates;
+	public double lengthInSeconds;
 
-	public MusicData(PlaybackController pbc, String[] sonifiableNames, Collection<List<Price>> prices) {
+	public MusicData(PlaybackController pbc, String[] sonifiableNames, Collection<List<Price>> prices, double lengthInSeconds) {
 		assert sonifiableNames.length == prices.size();
 		this.pbc = pbc;
 		this.sonifiableNames = sonifiableNames;
+		this.lengthInSeconds = lengthInSeconds;
 
 		this.maxPrice = 0;
 		this.dates = null;

--- a/src/main/java/app/communication/MusicData.java
+++ b/src/main/java/app/communication/MusicData.java
@@ -18,13 +18,11 @@ public class MusicData {
 	public List<XYChart.Series<Integer, Double>> prices;
 	public double maxPrice; // @Perfomance we already calculate this in the SM, so we could just get the value from there
 	public Calendar[] dates;
-	public double lengthInSeconds;
 
-	public MusicData(PlaybackController pbc, String[] sonifiableNames, Collection<List<Price>> prices, double lengthInSeconds) {
+	public MusicData(PlaybackController pbc, String[] sonifiableNames, Collection<List<Price>> prices) {
 		assert sonifiableNames.length == prices.size();
 		this.pbc = pbc;
 		this.sonifiableNames = sonifiableNames;
-		this.lengthInSeconds = lengthInSeconds;
 
 		this.maxPrice = 0;
 		this.dates = null;

--- a/src/main/java/app/communication/MusicData.java
+++ b/src/main/java/app/communication/MusicData.java
@@ -16,6 +16,7 @@ public class MusicData {
 	// It is also guranteed that every inner array in prices has the same length
 	public String[] sonifiableNames;
 	public List<XYChart.Series<Integer, Double>> prices;
+	public double maxPrice; // @Perfomance we already calculate this in the SM, so we could just get the value from there
 	public Calendar[] dates;
 
 	public MusicData(PlaybackController pbc, String[] sonifiableNames, Collection<List<Price>> prices) {
@@ -23,6 +24,7 @@ public class MusicData {
 		this.pbc = pbc;
 		this.sonifiableNames = sonifiableNames;
 
+		this.maxPrice = 0;
 		this.dates = null;
 		this.prices = new ArrayList<>(prices.size());
 		for (List<Price> priceList : prices) {
@@ -33,6 +35,8 @@ public class MusicData {
 			XYChart.Series<Integer, Double> series = new XYChart.Series<>();
 			for (int i = 0; i < priceList.size(); i++) {
 				double p = priceList.get(i).getOpen();
+				if (p > maxPrice)
+					maxPrice = p;
 				if (p != 0)
 					series.getData().add(new XYChart.Data<>(i, p));
 				if (firstIteration)

--- a/src/main/java/app/communication/MusicData.java
+++ b/src/main/java/app/communication/MusicData.java
@@ -32,7 +32,9 @@ public class MusicData {
 
 			XYChart.Series<Integer, Double> series = new XYChart.Series<>();
 			for (int i = 0; i < priceList.size(); i++) {
-				series.getData().add(new XYChart.Data<>(i, priceList.get(i).getOpen()));
+				double p = priceList.get(i).getOpen();
+				if (p != 0)
+					series.getData().add(new XYChart.Data<>(i, p));
 				if (firstIteration)
 					this.dates[i] = priceList.get(i).getDay();
 			}

--- a/src/main/java/app/ui/CommonController.java
+++ b/src/main/java/app/ui/CommonController.java
@@ -1,6 +1,7 @@
 package app.ui;
 
 import javafx.scene.layout.Pane;
+import util.DateUtil;
 import javafx.scene.control.Label;
 import javafx.scene.control.Button;
 
@@ -27,13 +28,18 @@ public class CommonController {
         errorTit.setWrapText(true);
         Button close = new Button("Schließen");
         close.setOnMouseClicked(event ->{
-                parent.getChildren().remove(errorPane);
+            parent.getChildren().remove(errorPane);
         });
         close.setLayoutX(330);
         close.setLayoutY(20);
         close.setId("closeBtn");
         errorPane.getChildren().addAll(errorMes, close, errorTit);
         parent.getChildren().add(errorPane);
+    }
 
+    public static String secToMinSecString(double secs, int minStrLen) {
+        int quot = (int) (secs / 60);
+        int rest = (int) Math.round(secs - quot * 60);
+        return DateUtil.paddedParse(quot, minStrLen, '0') + ":" + DateUtil.paddedParse(rest, 2, '0');
     }
 }

--- a/src/main/java/app/ui/MusicSceneController.java
+++ b/src/main/java/app/ui/MusicSceneController.java
@@ -51,43 +51,28 @@ public class MusicSceneController implements Initializable {
 		Paint.valueOf("#891fff"), Paint.valueOf("#07321d")
 	};
 
-	@FXML
-	private AnchorPane anchor;
-	@FXML
-	private LineChart<Integer, Double> lineChart;
-	@FXML
-	private NumberAxis xAxis;
-	@FXML
-	private NumberAxis yAxis;
-	@FXML
-	private Pane legendPane;
-	@FXML
-	private TextField headerTitle;
-	@FXML
-	private Stage stage;
-	@FXML
-	private Scene scene;
-	@FXML
-	private Button exportBtn;
-	@FXML
-	private Button closeBtn;
-	@FXML
-	private Slider musicSlider;
-	@FXML
-	private Parent root;
-	@FXML
-	private ImageView playBtn;
-	@FXML
-	private ImageView stopBtn;
-	@FXML
-	private ImageView backBtn;
-	@FXML
-	private ImageView forBtn;
+	@FXML private AnchorPane anchor;
+	@FXML private LineChart<Integer, Double> lineChart;
+	@FXML private NumberAxis xAxis;
+	@FXML private NumberAxis yAxis;
+	@FXML private Pane legendPane;
+	@FXML private TextField headerTitle;
+	@FXML private Stage stage;
+	@FXML private Scene scene;
+	@FXML private Button exportBtn;
+	@FXML private Button closeBtn;
+	@FXML private Slider musicSlider;
+	@FXML private Parent root;
+	@FXML private ImageView playBtn;
+	@FXML private ImageView stopBtn;
+	@FXML private ImageView backBtn;
+	@FXML private ImageView forBtn;
 
 	private CheckEQService checkEQService;
 	private PlaybackController pbc;
 	private String[] sonifiableNames;
 	private List<XYChart.Series<Integer, Double>> prices;
+	private double maxPrice;
 	private Calendar[] dates;
 	private Timer myTimer = new Timer();
 	private boolean paused = false;
@@ -166,10 +151,11 @@ public class MusicSceneController implements Initializable {
 	}
 
 	public void passData(MusicData musicData) {
-		this.pbc = musicData.pbc;
+		this.pbc             = musicData.pbc;
 		this.sonifiableNames = musicData.sonifiableNames;
-		this.prices = musicData.prices;
-		this.dates = musicData.dates;
+		this.prices          = musicData.prices;
+		this.dates           = musicData.dates;
+		this.maxPrice        = musicData.maxPrice;
 
 		assert sonifiableNames.length <= colors.length;
 		Platform.runLater(() -> {
@@ -199,6 +185,17 @@ public class MusicSceneController implements Initializable {
 			}
 			public Number fromString(String string) {
 				return 0;
+			}
+		});
+		yAxis.setAutoRanging(false);
+		yAxis.setLowerBound(0);
+		yAxis.setUpperBound(Math.ceil(maxPrice / 10) * 10);
+		yAxis.setTickLabelFormatter(new StringConverter<Number>() {
+			public String toString(Number i) {
+				return i.toString() + "$";
+			}
+			public Number fromString(String string) {
+				return Double.parseDouble(string.substring(0, string.length() - 1));
 			}
 		});
 

--- a/src/main/java/app/ui/MusicSceneController.java
+++ b/src/main/java/app/ui/MusicSceneController.java
@@ -34,7 +34,6 @@ import javafx.util.Duration;
 import javafx.util.StringConverter;
 import util.ArrayFunctions;
 import util.DateUtil;
-import util.Maths;
 
 import java.io.File;
 import java.io.IOException;
@@ -159,7 +158,7 @@ public class MusicSceneController implements Initializable {
 		this.prices          = musicData.prices;
 		this.dates           = musicData.dates;
 		this.maxPrice        = musicData.maxPrice;
-		this.lengthInSeconds = musicData.lengthInSeconds;
+		this.lengthInSeconds = pbc.getLengthInSeconds();
 		this.lengthStr       = CommonController.secToMinSecString(lengthInSeconds, 1);
 
 		assert sonifiableNames.length <= colors.length;

--- a/src/main/java/audio/Sonifier.java
+++ b/src/main/java/audio/Sonifier.java
@@ -20,16 +20,24 @@ import javax.sound.sampled.SourceDataLine;
 import static audio.Util.concatArrays;
 
 public class Sonifier {
-    public static PlaybackController sonify(InstrumentDataRaw[] instrumentDataRaw, EvInstrData[] evInstrData, int lengthInSecondsRaw) throws AppError{
+    public static Backing getBacking() throws AppError {
         Backing backing = new Backing();
         Constants.TEMPO = backing.setSamplesAndGetTempo();
+        return backing;
+    }
 
+    public static int getLengthInBeats(int lengthInSecondsRaw) {
         double numberBeatsRaw = (Constants.TEMPO / 60f) * lengthInSecondsRaw;
         // get number of beats to nearest multiple of 16 so that audio always lasts for
         // a full multiple of 4 bars
-        int lengthInBeats = (int) Math.round(numberBeatsRaw / 16) * 16;
-        double lengthInSeconds = lengthInBeats / (Constants.TEMPO / 60f);
+        return (int) Math.round(numberBeatsRaw / 16) * 16;
+    }
 
+    public static double getLengthInSeconds(int lengthInSecondsRaw, int lengthInBeats) {
+        return lengthInBeats / (Constants.TEMPO / 60f);
+    }
+
+    public static PlaybackController sonify(InstrumentDataRaw[] instrumentDataRaw, EvInstrData[] evInstrData, Backing backing, double lengthInSeconds, int lengthInBeats) throws AppError {
         double[][] synthLines = new double[instrumentDataRaw.length + 1][];
         for(int i = 0; i < instrumentDataRaw.length; i++){
             InstrumentData instrData = new Harmonizer(instrumentDataRaw[i], lengthInBeats).harmonize();

--- a/src/main/java/audio/Sonifier.java
+++ b/src/main/java/audio/Sonifier.java
@@ -20,24 +20,16 @@ import javax.sound.sampled.SourceDataLine;
 import static audio.Util.concatArrays;
 
 public class Sonifier {
-    public static Backing getBacking() throws AppError {
+    public static PlaybackController sonify(InstrumentDataRaw[] instrumentDataRaw, EvInstrData[] evInstrData, int lengthInSecondsRaw) throws AppError {
         Backing backing = new Backing();
         Constants.TEMPO = backing.setSamplesAndGetTempo();
-        return backing;
-    }
 
-    public static int getLengthInBeats(int lengthInSecondsRaw) {
         double numberBeatsRaw = (Constants.TEMPO / 60f) * lengthInSecondsRaw;
         // get number of beats to nearest multiple of 16 so that audio always lasts for
         // a full multiple of 4 bars
-        return (int) Math.round(numberBeatsRaw / 16) * 16;
-    }
+        int lengthInBeats = (int) Math.round(numberBeatsRaw / 16) * 16;
+        double lengthInSeconds = lengthInBeats / (Constants.TEMPO / 60f);
 
-    public static double getLengthInSeconds(int lengthInSecondsRaw, int lengthInBeats) {
-        return lengthInBeats / (Constants.TEMPO / 60f);
-    }
-
-    public static PlaybackController sonify(InstrumentDataRaw[] instrumentDataRaw, EvInstrData[] evInstrData, Backing backing, double lengthInSeconds, int lengthInBeats) throws AppError {
         double[][] synthLines = new double[instrumentDataRaw.length + 1][];
         for(int i = 0; i < instrumentDataRaw.length; i++){
             InstrumentData instrData = new Harmonizer(instrumentDataRaw[i], lengthInBeats).harmonize();
@@ -66,6 +58,6 @@ public class Sonifier {
             throw new RuntimeException(e);
         }
 
-        return new PlaybackController(sdl, out);
+        return new PlaybackController(sdl, out, lengthInSeconds);
     }
 }

--- a/src/main/java/audio/synth/playback/PlaybackController.java
+++ b/src/main/java/audio/synth/playback/PlaybackController.java
@@ -16,15 +16,23 @@ public class PlaybackController {
     public final int SKIP_LENGTH = 100;
     private final SourceDataLine s;
     private final short[] data;
+    private final double lengthInSeconds;
 
-    public PlaybackController(SourceDataLine s, short[] data) {
+    public PlaybackController(SourceDataLine s, short[] data, double lengthInSeconds) {
         this.s = s;
         this.data = data;
+        this.lengthInSeconds = lengthInSeconds;
     }
 
-    public PlaybackController(SourceDataLine s, double[] data){
+    public PlaybackController(SourceDataLine s, double[] data, double lengthInSeconds) {
         this.s = s;
         this.data = Util.scaleToShort(data);
+        this.lengthInSeconds = lengthInSeconds;
+    }
+
+    // Returns length of audio stream in seconds
+    public double getLengthInSeconds() {
+        return lengthInSeconds;
     }
 
     public double getPlayedPercentage() {

--- a/src/main/resources/MusicScene.fxml
+++ b/src/main/resources/MusicScene.fxml
@@ -31,11 +31,16 @@
         </yAxis>
       </LineChart>
       <Accordion layoutX="221.0" layoutY="880.0" />
+      <Label fx:id="lengthLabel" layoutX="1485.0" layoutY="630.0" text="0:00/0:00" textFill="WHITE" >
+         <font>
+            <Font name="System Bold" size="15.0" />
+         </font>
+      </Label>
 
-      <Pane fx:id="legendPane">
+      <Pane fx:id="legendPane" >
       </Pane>
 
-      <Button fx:id="exportBtn" layoutX="1243.0" layoutY="21.0" mnemonicParsing="false" onAction="#beginTimer" prefHeight="45.0" prefWidth="146.0" style="-fx-background-color: #121315; -fx-border-radius: 30;" text="Exportieren" textFill="WHITE">
+      <Button fx:id="exportBtn" layoutX="1243.0" layoutY="21.0" mnemonicParsing="false" prefHeight="45.0" prefWidth="146.0" style="-fx-background-color: #121315; -fx-border-radius: 30;" text="Exportieren" textFill="WHITE">
          <font>
             <Font size="19.0" />
          </font>


### PR DESCRIPTION
- Bei Y-Achse wird jede Zahl jetzt um ein Dollarzeichen ergänzt, um die Einheit klar zu stellen
- Bei der Playback-Timeline wird jetzt die bereits gespielte und Gesamtlänge des Audio-Streams angezeigt

@Musik-Team, um die Zeit in Sekunden (die für den 2. Punkt oben nötig waren), musste ich die Struktur beim Sonifier leicht anpassen. Es funktioniert noch alles so wie vorher, aber sagt Bescheid, wenn euch das so nicht passt