### PR TITLE
UI string fixes

### DIFF
--- a/src/main/java/app/StateManager.java
+++ b/src/main/java/app/StateManager.java
@@ -4,7 +4,6 @@ import app.communication.*;
 import app.mapping.*;
 import app.ui.App;
 import audio.Sonifier;
-import audio.mixer.Backing;
 import audio.synth.EvInstrData;
 import audio.synth.EvInstrEnum;
 import audio.synth.InstrumentEnum;
@@ -165,7 +164,7 @@ public class StateManager {
 		return false;
 	}
 
-	public static boolean[] calcRangeData(ExchangeData<RangeData> ed, HashMap<SonifiableID, List<Price>> priceMap) throws AppError {
+	public static boolean[] calcRangeData(ExchangeData<RangeData> ed, HashMap<SonifiableID, List<Price>> priceMap) {
 		if (ed == null) return null;
 		List<Price> prices = priceMap.get(ed.getId());
 		int firstNoneNull = getValidPrice(prices, true);
@@ -278,7 +277,7 @@ public class StateManager {
 
 			// Create InstrumentDataRaw objects for Harmonizer
 			InstrumentMapping[] instrMappings = mapping.getMappedInstruments();
-			List<InstrumentDataRaw> instrRawDatas = new ArrayList<>(instrMappings.length);
+			List<InstrumentDataRaw> instrRawData = new ArrayList<>(instrMappings.length);
 			for (InstrumentMapping instrMap : instrMappings) {
 				if (instrMap.getPitch() == null)
 					continue;
@@ -298,11 +297,11 @@ public class StateManager {
 				boolean[] onOffFilter = calcRangeData(instrMap.getOnOffFilter(), priceMap);
 				double[] pan = calcLineData(instrMap.getPan(), priceMap);
 
-				instrRawDatas.add(new InstrumentDataRaw(relVolume, absVolume, pitch, instrument, delayEcho, feedbackEcho,
+				instrRawData.add(new InstrumentDataRaw(relVolume, absVolume, pitch, instrument, delayEcho, feedbackEcho,
 						onOffEcho, delayReverb, feedbackReverb, onOffReverb, frequency, highPass, onOffFilter, pan));
 			}
-			InstrumentDataRaw[] passedInstrRawDatas = new InstrumentDataRaw[instrRawDatas.size()];
-			passedInstrRawDatas = instrRawDatas.toArray(passedInstrRawDatas);
+			InstrumentDataRaw[] passedInstrRawDatas = new InstrumentDataRaw[instrRawData.size()];
+			passedInstrRawDatas = instrRawData.toArray(passedInstrRawDatas);
 
 			List<EvInstrData> evInstrRawDatas = new ArrayList<>();
 			for(EvInstrMapping evInstrMap : mapping.getEventInstruments()){

--- a/src/main/java/app/mapping/InstrParam.java
+++ b/src/main/java/app/mapping/InstrParam.java
@@ -11,14 +11,13 @@ public enum InstrParam {
 	FEEDBACK_REVERB,
 	ON_OFF_REVERB,
 	CUTOFF,
-	ORDER,
 	ON_OFF_FILTER,
 	HIGHPASS,
 	PAN;
 
 	public static InstrParam[] LineDataParams = { PITCH, RELVOLUME, DELAY_ECHO, FEEDBACK_ECHO, DELAY_REVERB,
 			FEEDBACK_REVERB,
-			CUTOFF, ORDER, PAN };
+			CUTOFF, PAN };
 	public static InstrParam[] RangeDataParams = { ABSVOLUME, ON_OFF_FILTER, ON_OFF_REVERB, ON_OFF_ECHO };
 	public static InstrParam[] BoolParams = { HIGHPASS };
 
@@ -35,7 +34,6 @@ public enum InstrParam {
 			case "Feedback_Reverb" -> FEEDBACK_REVERB;
 			case "On_Off_Reverb" -> ON_OFF_REVERB;
 			case "Cutoff" -> CUTOFF;
-			case "Order" -> ORDER;
 			case "On_Off_Filter" -> ON_OFF_FILTER;
 			case "Highpass" -> HIGHPASS;
 			case "Pan" -> PAN;
@@ -55,7 +53,6 @@ public enum InstrParam {
 			case FEEDBACK_REVERB -> "Feedback_Reverb";
 			case ON_OFF_REVERB -> "On_Off_Reverb";
 			case CUTOFF -> "Cutoff";
-			case ORDER -> "Order";
 			case ON_OFF_FILTER -> "On_Off_Filter";
 			case HIGHPASS -> "Highpass";
 			case PAN -> "Pan";

--- a/src/main/java/app/mapping/InstrParam.java
+++ b/src/main/java/app/mapping/InstrParam.java
@@ -44,16 +44,16 @@ public enum InstrParam {
 	public String toString() {
 		return switch (this) {
 			case PITCH -> "Pitch";
-			case RELVOLUME -> "Relvolume";
-			case ABSVOLUME -> "Absvolume";
-			case DELAY_ECHO -> "Delay_Echo";
-			case FEEDBACK_ECHO -> "Feedback_Echo";
-			case ON_OFF_ECHO -> "On_Off_Echo";
-			case DELAY_REVERB -> "Delay_Reverb";
-			case FEEDBACK_REVERB -> "Feedback_Reverb";
-			case ON_OFF_REVERB -> "On_Off_Reverb";
-			case CUTOFF -> "Cutoff";
-			case ON_OFF_FILTER -> "On_Off_Filter";
+			case RELVOLUME -> "Lautstärke";
+			case ABSVOLUME -> "An/Aus";
+			case DELAY_ECHO -> "Echo: Delay";
+			case FEEDBACK_ECHO -> "Echo: Level";
+			case ON_OFF_ECHO -> "Echo: An/Aus";
+			case DELAY_REVERB -> "Reverb: Delay";
+			case FEEDBACK_REVERB -> "Reverb: Level";
+			case ON_OFF_REVERB -> "Reverb: An/Aus";
+			case CUTOFF -> "Filter: Frequenz";
+			case ON_OFF_FILTER -> "Filter: An/Aus";
 			case HIGHPASS -> "Highpass";
 			case PAN -> "Pan";
 		};

--- a/src/main/java/app/mapping/InstrumentMapping.java
+++ b/src/main/java/app/mapping/InstrumentMapping.java
@@ -49,7 +49,6 @@ public class InstrumentMapping {
 		if (delayReverb    == null || oldVal == InstrParam.DELAY_REVERB)     params.add(InstrParam.DELAY_REVERB);
 		if (feedbackReverb == null || oldVal == InstrParam.FEEDBACK_REVERB)  params.add(InstrParam.FEEDBACK_REVERB);
 		if (cutoff         == null || oldVal == InstrParam.CUTOFF)           params.add(InstrParam.CUTOFF);
-		if (order          == null || oldVal == InstrParam.ORDER)            params.add(InstrParam.ORDER);
 		InstrParam[] out = new InstrParam[params.size()];
 		return params.toArray(out);
 	}
@@ -124,7 +123,6 @@ public class InstrumentMapping {
 			case FEEDBACK_REVERB -> feedbackEcho = null;
 			case ON_OFF_REVERB   -> onOffReverb = null;
 			case CUTOFF          -> cutoff = null;
-			case ORDER           -> order = null;
 			case ON_OFF_FILTER   -> onOffFilter = null;
 			case PAN             -> pan = null;
 			default              -> {}
@@ -143,7 +141,6 @@ public class InstrumentMapping {
 			case FEEDBACK_REVERB -> getFeedbackEcho();
 			case ON_OFF_REVERB   -> getOnOffReverb();
 			case CUTOFF          -> getCutoff();
-			case ORDER           -> getOrder();
 			case ON_OFF_FILTER   -> getOnOffFilter();
 			case PAN             -> getPan();
 			default              -> null;
@@ -158,7 +155,6 @@ public class InstrumentMapping {
 		if (ed.equals(delayReverb))    return InstrParam.DELAY_REVERB;
 		if (ed.equals(feedbackReverb)) return InstrParam.FEEDBACK_REVERB;
 		if (ed.equals(cutoff))         return InstrParam.CUTOFF;
-		if (ed.equals(order))          return InstrParam.ORDER;
 		if (ed.equals(absVolume))      return InstrParam.ABSVOLUME;
 		if (ed.equals(onOffEcho))      return InstrParam.ON_OFF_ECHO;
 		if (ed.equals(onOffReverb))    return InstrParam.ON_OFF_REVERB;
@@ -250,14 +246,6 @@ public class InstrumentMapping {
 		this.cutoff = cutoff;
 	}
 
-	public ExchangeData<LineData> getOrder() {
-		return this.order;
-	}
-
-	public void setOrder(ExchangeData<LineData> order) {
-		this.order = order;
-	}
-
 	public ExchangeData<RangeData> getOnOffFilter() {
 		return this.onOffFilter;
 	}
@@ -296,7 +284,6 @@ public class InstrumentMapping {
 				", feedbackReverb='" + this.feedbackReverb + "'" +
 				", onOffReverb='" + this.onOffReverb + "'" +
 				", cutoff='" + this.cutoff + "'" +
-				", order='" + this.order + "'" +
 				", onOffFilter='" + this.onOffFilter + "'" +
 				", highPass='" + this.highPass + "'" +
 				", pan='" + this.pan + "'" +

--- a/src/main/java/app/mapping/Mapping.java
+++ b/src/main/java/app/mapping/Mapping.java
@@ -248,7 +248,6 @@ public class Mapping {
 			case FEEDBACK_REVERB -> instrMap.setFeedbackReverb(setParamHelper(id, eparam, iparam));
 			case ON_OFF_REVERB   -> instrMap.setOnOffReverb(setParamHelper(id, eparam, iparam));
 			case CUTOFF          -> instrMap.setCutoff(setParamHelper(id, eparam, iparam));
-			case ORDER           -> instrMap.setOrder(setParamHelper(id, eparam, iparam));
 			case ON_OFF_FILTER   -> instrMap.setOnOffFilter(setParamHelper(id, eparam, iparam));
 			case PAN             -> instrMap.setPan(setParamHelper(id, eparam, iparam));
 			case HIGHPASS        -> throw new AppError(eparam.toString() + " kann nicht auf " + iparam + " gemappt werden.");
@@ -269,7 +268,6 @@ public class Mapping {
 			case FEEDBACK_REVERB -> instrMap.getFeedbackReverb() != null;
 			case ON_OFF_REVERB   -> instrMap.getOnOffReverb() != null;
 			case CUTOFF          -> instrMap.getCutoff() != null;
-			case ORDER           -> instrMap.getOrder() != null;
 			case ON_OFF_FILTER   -> instrMap.getOnOffFilter() != null;
 			case PAN             -> instrMap.getPan() != null;
 			case HIGHPASS        -> throw new AppError(iparam + " kann nicht gemappt sein");
@@ -289,7 +287,6 @@ public class Mapping {
 			case FEEDBACK_REVERB -> instrMap.setFeedbackReverb(null);
 			case ON_OFF_REVERB   -> instrMap.setOnOffReverb(null);
 			case CUTOFF          -> instrMap.setCutoff(null);
-			case ORDER           -> instrMap.setOrder(null);
 			case ON_OFF_FILTER   -> instrMap.setOnOffFilter(null);
 			case PAN             -> instrMap.setPan(null);
 			case HIGHPASS        -> throw new AppError(iparam + " kann nicht gelöscht werden.");

--- a/src/main/java/app/ui/MainSceneController.java
+++ b/src/main/java/app/ui/MainSceneController.java
@@ -31,8 +31,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.text.ParseException;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.function.Function;
 
@@ -99,7 +97,6 @@ public class MainSceneController implements Initializable {
         instKeys[0] = "";
         instVals[0] = null;
         instKeys[1] = "Globale Audio-Parameter";
-        instVals[0] = null;
         for (int i = 0; i < insts.length; i++) {
             instKeys[i + 2] = insts[i].toString();
             instVals[i + 2] = insts[i];
@@ -168,16 +165,14 @@ public class MainSceneController implements Initializable {
         });
         checkEQService.start();
 
-        categoriesCB.getSelectionModel().selectedIndexProperty().addListener((observable, oldIdx, newIdx) -> {
-            EventQueues.toSM.add(new Msg<>(MsgToSMType.FILTERED_SONIFIABLES,
-                    new SonifiableFilter(searchBar.getText(), categoryValues[(int) newIdx])));
-        });
+        categoriesCB.getSelectionModel().selectedIndexProperty().addListener((observable, oldIdx, newIdx) ->
+                EventQueues.toSM.add(new Msg<>(MsgToSMType.FILTERED_SONIFIABLES,
+                new SonifiableFilter(searchBar.getText(), categoryValues[(int) newIdx]))));
         categoriesCB.getSelectionModel().selectFirst();
 
-        searchBar.textProperty().addListener((observable, oldVal, newVal) -> {
-            EventQueues.toSM.add(new Msg<>(MsgToSMType.FILTERED_SONIFIABLES, new SonifiableFilter(newVal,
-                    categoryValues[categoriesCB.getSelectionModel().getSelectedIndex()])));
-        });
+        searchBar.textProperty().addListener((observable, oldVal, newVal) ->
+                EventQueues.toSM.add(new Msg<>(MsgToSMType.FILTERED_SONIFIABLES, new SonifiableFilter(newVal,
+                categoryValues[categoriesCB.getSelectionModel().getSelectedIndex()]))));
 
         setDatePickerListeners(startPicker, true);
         setDatePickerListeners(endPicker, false);
@@ -366,11 +361,11 @@ public class MainSceneController implements Initializable {
         paneBoxSonifiables.getChildren().remove(paneIdx);
         if (updateSearchResult) {
             ObservableList<Node> checkBoxes = checkVBox.getChildren();
-            for (int i = 0; i < checkBoxes.size(); i++) {
+            for (Node c : checkBoxes) {
                 try {
-                    CheckBox c = (CheckBox) checkBoxes.get(i);
-                    if (((Sonifiable) c.getUserData()).getId() == id) {
-                        c.setSelected(false);
+                    CheckBox checkBox = (CheckBox) c;
+                    if (((Sonifiable) checkBox.getUserData()).getId() == id) {
+                        checkBox.setSelected(false);
                         break;
                     }
                 } catch (ClassCastException e) {
@@ -603,9 +598,9 @@ public class MainSceneController implements Initializable {
         addLine("pinkline", 512, 177, -100, -60, -100, 263, stockPane.getChildren());
         addStockParamToPane("Preis", "paneShareLabel", 14, 80, 14, 115, 14, 160, sonifiable, LineData.PRICE,
                 stockPane.getChildren(), showMapping);
-        addStockParamToPane("Gleitender Durchschnitt", "paneShareLabel", 14, 215, 14, 250, 14, 295, sonifiable,
+        addStockParamToPane("Gleitender Schnitt", "paneShareLabel", 14, 215, 14, 250, 14, 295, sonifiable,
                 LineData.MOVINGAVG, stockPane.getChildren(), showMapping);
-        addStockParamToPane("Steigungsgrad", "paneShareLabel", 14, 350, 14, 385, 14, 430, sonifiable,
+        addStockParamToPane("Steigung", "paneShareLabel", 14, 350, 14, 385, 14, 430, sonifiable,
                 LineData.RELCHANGE, stockPane.getChildren(), showMapping);
         addStockParamToPane("Flagge", "paneShareLabel", 226, 80, 226, 115, 226, 160, sonifiable, RangeData.FLAG,
                 stockPane.getChildren(), showMapping);
@@ -613,13 +608,13 @@ public class MainSceneController implements Initializable {
                 stockPane.getChildren(), showMapping);
         addStockParamToPane("V-Form", "paneShareLabel", 226, 350, 226, 385, 226, 430, sonifiable, RangeData.VFORM,
                 stockPane.getChildren(), showMapping);
-        addStockParamToPane("Trendbrüche", "paneShareLabel", 422, 80, 422, 115, 0, 0, sonifiable, PointData.TRENDBREAK,
+        addStockParamToPane("Trendbruch", "paneShareLabel", 422, 80, 422, 115, 0, 0, sonifiable, PointData.TRENDBREAK,
                 stockPane.getChildren(), showMapping);
-        addStockParamToPane("EQMOVINGAVG", "paneShareLabel", 422, 180, 422, 215, 0, 0, sonifiable,
+        addStockParamToPane("Preis = Schnitt", "paneShareLabel", 422, 180, 422, 215, 0, 0, sonifiable,
                 PointData.EQMOVINGAVG, stockPane.getChildren(), showMapping);
-        addStockParamToPane("EQSUPPORT", "paneShareLabel", 422, 280, 422, 315, 0, 0, sonifiable, PointData.EQSUPPORT,
+        addStockParamToPane("Preis = Stütz", "paneShareLabel", 422, 280, 422, 315, 0, 0, sonifiable, PointData.EQSUPPORT,
                 stockPane.getChildren(), showMapping);
-        addStockParamToPane("EQRESIST", "paneShareLabel", 422, 380, 422, 415, 0, 0, sonifiable, PointData.EQRESIST,
+        addStockParamToPane("Preis = Widerstand", "paneShareLabel", 422, 380, 422, 415, 0, 0, sonifiable, PointData.EQRESIST,
                 stockPane.getChildren(), showMapping);
 
         return stockPane;
@@ -637,11 +632,11 @@ public class MainSceneController implements Initializable {
         endPicker.setValue(DateUtil.calendarToLocalDate(mapping.getEndDate()));
         System.out.println("SoundLength: " + mapping.getSoundLength());
 
-        String min = Integer.toString((int) (mapping.getSoundLength() / 60));
-        String sec = Integer.toString(mapping.getSoundLength() % 60);
+        String min = Integer.toString( mapping.getSoundLength() / 60);
+        String sec = Integer.toString(mapping.getSoundLength() % 60 );
         audioLength1.setText(min);
         audioLength.setText(sec);
-        assert filterValues[0] == false;
+        assert !filterValues[0];
         filterCB.getSelectionModel().select(mapping.getHighPass() ? 1 : 0);
     }
 
@@ -690,7 +685,7 @@ public class MainSceneController implements Initializable {
         int idx = 0;
         for (Node child : instBox.getChildren()) {
             try {
-                if (((Label) child).getText() == name)
+                if (((Label) child).getText().equals(name))
                     break;
             } catch (Exception e) {
             }

--- a/src/main/resources/MainScene.fxml
+++ b/src/main/resources/MainScene.fxml
@@ -19,7 +19,7 @@
 <children>
 	<!-- Title -->
 	<Rectangle arcHeight="5.0" arcWidth="5.0" fill="#121315" height="85.6" stroke="#121315" strokeType="INSIDE" width="1584.0" />
-	<Label fx:id="headerTitle" layoutX="59.0" layoutY="-20.0" prefHeight="125.0" prefWidth="885.0" text="Sound Investments" textFill="WHITE">
+	<Label fx:id="headerTitle" layoutX="59.0" layoutY="-20.0" prefHeight="125.0" prefWidth="885.0" text="SoundInvestments" textFill="WHITE">
 		<font>
 			<Font name="Rage Italic" size="80.0" />
 		</font>
@@ -28,7 +28,7 @@
 	<!-- "Choosing Sonifiables"-Box -->
 	<Pane layoutX="29.0" layoutY="110.0" prefHeight="655.0" prefWidth="332.0" style="-fx-background-color: #D9D9D9; -fx-background-radius: 30;">
 		<children>
-			<Label layoutX="24.0" layoutY="21.0" prefHeight="53.0" prefWidth="131.0" style="-fx-font-style: &quot;Roboto&quot;;" text="Aktien">
+			<Label layoutX="24.0" layoutY="21.0" prefHeight="53.0" prefWidth="131.0" style="-fx-font-style: &quot;Roboto&quot;;" text="Kurse">
 				<font>
 					<Font name="System Bold" size="29.0" />
 				</font>

--- a/src/main/resources/MusicScene.fxml
+++ b/src/main/resources/MusicScene.fxml
@@ -16,7 +16,7 @@
 <AnchorPane fx:id="anchor" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="825.0" prefWidth="1586.0" style="-fx-background-color: #09080E;" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1" fx:controller="app.ui.MusicSceneController">
    <children>
       <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#121315" height="85.6" layoutX="-8.0" layoutY="1.0" stroke="#121315" strokeType="INSIDE" width="1592.0" />
-      <Label layoutX="83.0" layoutY="-18.0" prefHeight="124.0" prefWidth="885.0" text="Sound Investments" textFill="WHITE">
+      <Label layoutX="83.0" layoutY="-18.0" prefHeight="124.0" prefWidth="885.0" text="SoundInvestments" textFill="WHITE">
          <font>
             <Font name="Rage Italic" size="80.0" />
          </font>


### PR DESCRIPTION
Resolves #153 mainly changing the audio params' representation. As mentioned there @JakobPK should have a look at the data-relevant changes. I mainly swapped out the all-caps event names to German strings that might be a little more understandable. I hope they still mean the same.
I also changes the window title from `Sound Investments` to `SoundInvestments` in both scenes because we stylised it that way in all documents. It looks a bit weird in this font though so, please leave feedback on that.

Also did a little code cleanup in UI while I was at it.