### PR TITLE
Harmonizer bugfix

### DIFF
--- a/src/main/java/dhbw/si/audio/Harmonizer.java
+++ b/src/main/java/dhbw/si/audio/Harmonizer.java
@@ -278,7 +278,7 @@ public class Harmonizer {
         } else if (onOffEcho != null) {
             feedbackEcho = new double[onOffEcho.length];
             for (int i = 0; i < onOffEcho.length; i++) {
-                feedbackEcho[i] = onOffEcho[i] && delayEcho[i] != -1 ? DEFAULT_FEEDBACK_ECHO : MUTE_ECHO;
+                feedbackEcho[i] = onOffEcho[i] && delayEcho != null && delayEcho[i] != -1 ? DEFAULT_FEEDBACK_ECHO : MUTE_ECHO;
             }
         } else if (delayEcho != null) {
             feedbackEcho = new double[delayEcho.length];


### PR DESCRIPTION
I found a minor bug during testing some changes and quickly fixed it.

Issue: I had selected pitch and onOffDelay in the mapping and nothing else. The harmonizer then crashed because of a missing nullcheck (because delayEcho was never set). I just added a quick nullcheck there, but someone please check that this is correct.

