### PR TITLE
fix: synthesizing event instruments works now

### DIFF
--- a/src/main/java/dhbw/si/audio/events/EvInstrLine.java
+++ b/src/main/java/dhbw/si/audio/events/EvInstrLine.java
@@ -27,11 +27,13 @@ public class EvInstrLine {
         int samplesPer16th = (int) (60 / ((double)TEMPO * 4) * SAMPLE_RATE * CHANNEL_NO);
         int lastCopy = - 2* samplesPer16th;
 
-        for(int i = 0; i < out.length; i+=samplesPer16th){
-            if(data.values[Util.getRelPosition(i,out.length,data.values.length)] && lastCopy + 2 * samplesPer16th < i) {
-                lastCopy = i;
-                if(i + sample.length < out.length)
-                    System.arraycopy(sample, 0, out, i, sample.length);
+        for (int i = 0; i < data.values.length; i++) {
+            if (data.values[i]) {
+                int j = Util.getRelPosition(i, data.values.length, out.length);
+                if (lastCopy + 2 * samplesPer16th < j) {
+                    lastCopy = j;
+                    System.arraycopy(sample, 0, out, j, sample.length);
+                }
             }
         }
 


### PR DESCRIPTION
@nichtLehdev as we talked, I fixed the synthesizing of event instruments to not skip over any values (which it clearly did before). The quantization still seems to work (at least in the one test I did)