### PR TITLE
Api fixes

### DIFF
--- a/src/main/java/dhbw/si/dataRepo/DataRepo.java
+++ b/src/main/java/dhbw/si/dataRepo/DataRepo.java
@@ -176,6 +176,7 @@ public class DataRepo {
 					// We increase end by 1, because Leeway's range is exclusive
 					// and after each iteration end = earliestDay and it might be that we missed some data from that day
 					startEnd[1].roll(Calendar.DATE, true);
+					if (startEnd[1].before(startEnd[0])) break;
 					String[] queries = {"from", DateUtil.formatDate(startEnd[0]), "to", DateUtil.formatDate(startEnd[1])};
 					if (!isEoD) queries = ArrayFunctions.add(queries, intervalQueries);
 

--- a/src/main/java/dhbw/si/dataRepo/IntervalLength.java
+++ b/src/main/java/dhbw/si/dataRepo/IntervalLength.java
@@ -21,7 +21,7 @@ public enum IntervalLength {
 	public String toString() {
 		return switch (this) {
 			case MIN -> "5m";
-			case HOUR -> "1hour";
+			case HOUR -> "1h";
 			case DAY -> null; // In this case leeway expects you to use a different endpoint
 		};
 	}


### PR DESCRIPTION
Two very small but important fixes in the DataRepo. The first makes sure that 1-hour intervals work. And the second makes sure that we don't crash when the end date is lower than the start date for the time interval.