### PR TITLE
Show error message for invalid mapping

### DIFF
--- a/src/main/java/dhbw/si/app/ui/MainSceneController.java
+++ b/src/main/java/dhbw/si/app/ui/MainSceneController.java
@@ -178,6 +178,12 @@ public class MainSceneController implements Initializable {
 
         startBtn.setOnAction(ev -> {
             try {
+                String err = mapping.verify();
+                if (err != null) {
+                    CommonController.displayError(anchor, err, "Ungültiges Mapping");
+                    return;
+                }
+
                 startBtn.setDisable(true);
                 startedSonification = true;
                 EventQueues.toSM.add(new Msg<>(MsgToSMType.START, mapping));
@@ -652,7 +658,7 @@ public class MainSceneController implements Initializable {
     }
 
     private void enableBtnIfValid() {
-        startBtn.setDisable(startedSonification || !mapping.isValid());
+        startBtn.setDisable(startedSonification);
     }
 
     private void instAdded(String name) {


### PR DESCRIPTION
A very simple change to show an error message for invalid mappings to adress Kruse's criticism of this morning. Personally, I think this should be enough and I would probably be in favor of no other code changes. But since the fix was so easy and Kruse seemed to really dislike the lack of an error message in this case, I wanted to add this still